### PR TITLE
Create only one kubernetes namespace

### DIFF
--- a/group_vars/all.template
+++ b/group_vars/all.template
@@ -1,8 +1,7 @@
 # Kube data
 # Can be generated with kubeadm
 kube_token:
-prod_namespace: production
-test_namespace: develop
+kube_namespace: test
 
 # Node IPS
 # a list of every private ip from the platform

--- a/roles/caliopen/tasks/certs.yml
+++ b/roles/caliopen/tasks/certs.yml
@@ -13,5 +13,5 @@
   tags: ca-certs
 
 - name: create cert configmap
-  shell: kubectl create configmap ca-certs --from-file=/etc/caliopen/certs -n {{ prod_namespace }}
+  shell: kubectl create configmap ca-certs --from-file=/etc/caliopen/certs -n {{ kube_namespace }}
   tags: ca-certs

--- a/roles/caliopen/tasks/configs.yml
+++ b/roles/caliopen/tasks/configs.yml
@@ -13,7 +13,7 @@
   tags: config
 
 - name: create caliopen configs
-  shell: kubectl create configmap {{ name }}-config --from-file={{ name }}.{{ ext }} -n {{ prod_namespace }}
+  shell: kubectl create configmap {{ name }}-config --from-file={{ name }}.{{ ext }} -n {{ kube_namespace }}
   with_items:
     - { name: "apiv1", ext: "ini"}
     - { name: "apiv2", ext: "yaml"}
@@ -27,7 +27,7 @@
   tags: config
 
 - name: create frontend configmap
-  shell: kubectl create configmap frontend-config --from-literal=api_hostname=api.{{ caliopen_domain_name }} --from-literal=api_protocol=https --from-literal=api_port=443 -n {{ prod_namespace }}
+  shell: kubectl create configmap frontend-config --from-literal=api_hostname=api.{{ caliopen_domain_name }} --from-literal=api_protocol=https --from-literal=api_port=443 -n {{ kube_namespace }}
   tags: config
 
 - name: create system configs

--- a/roles/caliopen/tasks/main.yml
+++ b/roles/caliopen/tasks/main.yml
@@ -6,7 +6,7 @@
 - include: configs.yml
 
 - name: create services
-  shell: kubectl apply -f {{ yaml_url }}/services/{{ item }}-service.yaml -n {{ prod_namespace }}
+  shell: kubectl apply -f {{ yaml_url }}/services/{{ item }}-service.yaml -n {{ kube_namespace }}
   with_items:
     - apiv2
     - apiv1
@@ -15,7 +15,7 @@
   tags: service
 
 - name: create go app deployments
-  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ prod_namespace }}
+  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ kube_namespace }}
   with_items:
     - lmtpd
     - apiv2
@@ -25,14 +25,14 @@
   tags: [ go, deployment ]
 
 - name: create python app deployments
-  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ prod_namespace }}
+  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ kube_namespace }}
   with_items:
     - mq-worker
     - apiv1
   tags: [ python, deployment ]
 
 - name: create frontend app deployments
-  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ prod_namespace }}
+  shell: kubectl apply -f {{ yaml_url }}/deployments/{{ item }}-deployment.yaml -n {{ kube_namespace }}
   with_items:
     - frontend
   tags: [ frontend, deployment ]

--- a/roles/caliopen/tasks/namespaces_labels.yml
+++ b/roles/caliopen/tasks/namespaces_labels.yml
@@ -1,8 +1,7 @@
-- name: create production namespace
+- name: create kubernetes namespace
   shell: kubectl create namespace {{ item }}
   with_items:
-    - "{{ prod_namespace }}"
-    - "{{ test_namespace }}"
+    - "{{ kube_namespace }}"
   tags: namespace
 
 - name: label internal nodes

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -20,7 +20,7 @@
 - include: config_prometheus.yml
 
 - name: kube-system metric deployments
-  shell: kubectl apply -f {{ yaml_url }}/monitoring/{{ item }}.yaml -n {{ prod_namespace }}
+  shell: kubectl apply -f {{ yaml_url }}/monitoring/{{ item }}.yaml -n {{ kube_namespace }}
   with_items:
     - metrics-server
   tags: monitoring


### PR DESCRIPTION
Create only one kubernetes namespace and not a production and test one.

This way we can deploy caliopen into a specific namespace defined in group_vars/all file